### PR TITLE
Fix build on Mojave / Xcode 10

### DIFF
--- a/HGCLIAutoUpdater.m
+++ b/HGCLIAutoUpdater.m
@@ -148,8 +148,8 @@ NSComparisonResult versionNumberCompare(NSString *first, NSString *second)
         {
             if (error != NULL)
                 *error = NS_ERROR(0, ([NSString
-                            stringWithFormat:@"HTTP connection failed. Status code %d: \"%@\"",
-                            statusCode,
+                            stringWithFormat:@"HTTP connection failed. Status code %ld: \"%@\"",
+                            (long)statusCode,
                             [NSHTTPURLResponse localizedStringForStatusCode:statusCode]]));
             return nil;
         }

--- a/HGDateFunctions.m
+++ b/HGDateFunctions.m
@@ -171,13 +171,13 @@ NSInteger getWeekDiff(NSDate *date1, NSDate *date2)
     // of the last days in a year is often week #1 of the next
     // year) -- if so, they are directly comparable
     if ((year1 == year2) ||
-        (abs(year1-year2)==1 && earlierDateWeek==1))
-        return abs(week2-week1);
+        (labs(year1-year2)==1 && earlierDateWeek==1))
+        return labs(week2-week1);
 
     // if there is more than one year between the dates, get the
     // total number of weeks in the years between
     NSInteger numWeeksInYearsBetween = 0;
-    if (abs(year1-year2) > 1)
+    if (labs(year1-year2) > 1)
     {
         NSInteger i;
         for (i = earlierDateYear+1; i < laterDateYear; i++)
@@ -254,8 +254,8 @@ BOOL naturalLanguageDateSpecifiesTime(NSString *input, NSDate *resultDate)
     // towards falsely assuming that no time has been specified than the other
     // way.
     NSUInteger occurrencesOf12InDate = 0;
-    occurrencesOf12InDate = countOccurrences([NSString stringWithFormat:@"%i-%i-%i",
-                                              [resultComps year], [resultComps month], [resultComps day]],
+    occurrencesOf12InDate = countOccurrences([NSString stringWithFormat:@"%ld-%ld-%ld",
+                                              (long)[resultComps year], (long)[resultComps month], (long)[resultComps day]],
                                               @"12", NSLiteralSearch);
     if (countOccurrences(input, @"12", NSLiteralSearch) > occurrencesOf12InDate)
         return YES;

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,7 @@ COMPILER_GCC=gcc
 COMPILER_CLANG=clang
 COMPILER=$(COMPILER_CLANG)
 
-CC_WARN_OPTS=-Wall -Wextra -Wno-unused-parameter -Werror
-
-ifdef 64BIT
-	ARCH_64BIT=-arch x86_64
-else
-	ARCH_64BIT=
-endif
+CC_WARN_OPTS=-Wall -Wextra -Wno-unused-parameter
 
 ifdef DEBUG
 	ARG_DEBUG=-g
@@ -54,7 +48,7 @@ icalBuddy: $(SOURCE_FILES) icalBuddy.m
 	@echo
 	@echo ---- Compiling main app:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 $(CC_WARN_OPTS) -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch i386 $(ARCH_64BIT) -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m $(SOURCE_FILES)
+	$(COMPILER) $(ARG_DEBUG) -O3 $(CC_WARN_OPTS) -std=c99 -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m $(SOURCE_FILES)
 
 
 
@@ -66,7 +60,7 @@ testIcalBuddy: $(SOURCE_FILES) icalBuddy.m calendarStoreMock/*.m
 	@echo
 	@echo ---- Compiling TEST version of main app:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch i386 $(ARCH_64BIT) -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m calendarStoreMock/*.m $(SOURCE_FILES)
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m calendarStoreMock/*.m $(SOURCE_FILES)
 
 
 
@@ -93,7 +87,7 @@ testRunner: $(SOURCE_FILES)
 	@echo
 	@echo ---- Compiling test runner:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch i386 -arch ppc $(ARCH_64BIT) -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
 
 
 

--- a/icalBuddyArgs.m
+++ b/icalBuddyArgs.m
@@ -131,11 +131,11 @@ void handleArgument(NSString *shortName, NSString *longName, id value,
         if ([value respondsToSelector:@selector(integerValue)])
         {
             if ([shortName isEqualToString:@"li"] || [longName isEqualToString:@"limitItems"])
-                prettyPrintOptions->maxNumPrintedItems = abs([value integerValue]);
+                prettyPrintOptions->maxNumPrintedItems = labs([value integerValue]);
             else if ([shortName isEqualToString:@"na"] || [longName isEqualToString:@"maxNumAttendees"])
-                opts->maxNumPrintedAttendees = abs([value integerValue]);
+                opts->maxNumPrintedAttendees = labs([value integerValue]);
             else if ([shortName isEqualToString:@"nnc"] || [longName isEqualToString:@"maxNumNoteChars"])
-                opts->maxNumNoteCharacters = abs([value integerValue]);
+                opts->maxNumNoteCharacters = labs([value integerValue]);
         }
     }
 }

--- a/icalBuddyPrettyPrint.m
+++ b/icalBuddyPrettyPrint.m
@@ -169,7 +169,7 @@ NSString* dateStr(NSDate *date, DatePrintOption printOption)
 
                     NSString *weekDiffStr = nil;
                     if (weekDiff < -1)
-                        weekDiffStr = [NSString stringWithFormat:localizedStr(kL10nKeyXWeeksAgo), abs(weekDiff)];
+                        weekDiffStr = [NSString stringWithFormat:localizedStr(kL10nKeyXWeeksAgo), labs(weekDiff)];
                     else if (weekDiff == -1)
                         weekDiffStr = localizedStr(kL10nKeyLastWeek);
                     else if (weekDiff == 0)
@@ -194,7 +194,7 @@ NSString* dateStr(NSDate *date, DatePrintOption printOption)
 
                     NSString *dayDiffStr = nil;
                     if (dayDiff < -1)
-                        dayDiffStr = [NSString stringWithFormat:localizedStr(kL10nKeyXDaysAgo), abs(dayDiff)];
+                        dayDiffStr = [NSString stringWithFormat:localizedStr(kL10nKeyXDaysAgo), labs(dayDiff)];
                     else if (dayDiff == -1)
                         dayDiffStr = localizedStr(kL10nKeyYesterday);
                     else if (dayDiff == 0)
@@ -830,7 +830,7 @@ NSString *localizedPriority(CalPriority priority)
             return localizedStr(kL10nKeyPriorityNone);
             break;
     }
-    return [NSString stringWithFormat:@"%d", priority];
+    return [NSString stringWithFormat:@"%ld", (long)priority];
 }
 
 NSString *localizedPriorityTitle(CalPriority priority)


### PR DESCRIPTION
icalBuddy does not build on macOS 10.14 Mojave, with Xcode 10. Part of the content is borrowed from #18.

- Remove all arch flags, always build for the default arch. With Mojave, 32-bit builds (forced by `-arch i386`) are no longer supported.
- Remove `-Werror`, given there are lot of deprecation warnings for old APIs, which otherwise prevent the build to succeed.
- Remove `-mmacosx-version-min=10.5`, which is not supported on Mojave anymore.
- Remove `-force_cpusubtype_ALL`, which was a PowerPC option.