### PR TITLE
Made stuff work with 64-bit Macs

### DIFF
--- a/HGCLIAutoUpdater.m
+++ b/HGCLIAutoUpdater.m
@@ -148,8 +148,8 @@ NSComparisonResult versionNumberCompare(NSString *first, NSString *second)
         {
             if (error != NULL)
                 *error = NS_ERROR(0, ([NSString
-                            stringWithFormat:@"HTTP connection failed. Status code %d: \"%@\"",
-                            statusCode,
+                            stringWithFormat:@"HTTP connection failed. Status code %ld: \"%@\"",
+                            (long) statusCode,
                             [NSHTTPURLResponse localizedStringForStatusCode:statusCode]]));
             return nil;
         }

--- a/HGDateFunctions.m
+++ b/HGDateFunctions.m
@@ -171,13 +171,13 @@ NSInteger getWeekDiff(NSDate *date1, NSDate *date2)
     // of the last days in a year is often week #1 of the next
     // year) -- if so, they are directly comparable
     if ((year1 == year2) ||
-        (abs(year1-year2)==1 && earlierDateWeek==1))
-        return abs(week2-week1);
+        (labs(year1-year2)==1 && earlierDateWeek==1))
+        return labs(week2-week1);
 
     // if there is more than one year between the dates, get the
     // total number of weeks in the years between
     NSInteger numWeeksInYearsBetween = 0;
-    if (abs(year1-year2) > 1)
+    if (labs(year1-year2) > 1)
     {
         NSInteger i;
         for (i = earlierDateYear+1; i < laterDateYear; i++)
@@ -254,8 +254,8 @@ BOOL naturalLanguageDateSpecifiesTime(NSString *input, NSDate *resultDate)
     // towards falsely assuming that no time has been specified than the other
     // way.
     NSUInteger occurrencesOf12InDate = 0;
-    occurrencesOf12InDate = countOccurrences([NSString stringWithFormat:@"%i-%i-%i",
-                                              [resultComps year], [resultComps month], [resultComps day]],
+    occurrencesOf12InDate = countOccurrences([NSString stringWithFormat:@"%li-%li-%li",
+                                              (long) [resultComps year], (long) [resultComps month], (long) [resultComps day]],
                                               @"12", NSLiteralSearch);
     if (countOccurrences(input, @"12", NSLiteralSearch) > occurrencesOf12InDate)
         return YES;

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ icalBuddy: $(SOURCE_FILES) icalBuddy.m
 	@echo
 	@echo ---- Compiling main app:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 $(CC_WARN_OPTS) -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch i386 $(ARCH_64BIT) -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m $(SOURCE_FILES)
+	$(COMPILER) $(ARG_DEBUG) -O3 $(CC_WARN_OPTS) -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  $(ARCH_64BIT) -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m $(SOURCE_FILES)
 
 
 
@@ -66,7 +66,7 @@ testIcalBuddy: $(SOURCE_FILES) icalBuddy.m calendarStoreMock/*.m
 	@echo
 	@echo ---- Compiling TEST version of main app:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch i386 $(ARCH_64BIT) -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m calendarStoreMock/*.m $(SOURCE_FILES)
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  $(ARCH_64BIT) -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m calendarStoreMock/*.m $(SOURCE_FILES)
 
 
 
@@ -93,7 +93,7 @@ testRunner: $(SOURCE_FILES)
 	@echo
 	@echo ---- Compiling test runner:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch i386 -arch ppc $(ARCH_64BIT) -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  -arch ppc $(ARCH_64BIT) -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -26,18 +26,6 @@ COMPILER=$(COMPILER_CLANG)
 
 CC_WARN_OPTS=-Wall -Wextra -Wno-unused-parameter -Werror
 
-ifdef 64BIT
-	ARCH_64BIT=-arch x86_64
-else
-	ARCH_64BIT=
-endif
-
-ifdef DEBUG
-	ARG_DEBUG=-g
-else
-	ARG_DEBUG=
-endif
-
 SOURCE_FILES=icalBuddy[ABCDEFGHIJKLMNOPQRSTUVWXYZ]*.m ANSIEscapeHelper.m HG*.m IcalBuddy*.m *+HGAdditions.m
 
 
@@ -54,7 +42,7 @@ icalBuddy: $(SOURCE_FILES) icalBuddy.m
 	@echo
 	@echo ---- Compiling main app:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 $(CC_WARN_OPTS) -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  $(ARCH_64BIT) -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m $(SOURCE_FILES)
+	$(COMPILER) $(ARG_DEBUG) -O3 $(CC_WARN_OPTS) -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  -arch x86_64 -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m $(SOURCE_FILES)
 
 
 
@@ -66,7 +54,7 @@ testIcalBuddy: $(SOURCE_FILES) icalBuddy.m calendarStoreMock/*.m
 	@echo
 	@echo ---- Compiling TEST version of main app:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  $(ARCH_64BIT) -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m calendarStoreMock/*.m $(SOURCE_FILES)
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  -arch x86_64 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m calendarStoreMock/*.m $(SOURCE_FILES)
 
 
 
@@ -93,7 +81,7 @@ testRunner: $(SOURCE_FILES)
 	@echo
 	@echo ---- Compiling test runner:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  -arch ppc $(ARCH_64BIT) -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  -arch ppc -arch x86_64 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ testRunner: $(SOURCE_FILES)
 	@echo
 	@echo ---- Compiling test runner:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  -arch ppc -arch x86_64 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch x86_64 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
 
 
 

--- a/icalBuddy.m
+++ b/icalBuddy.m
@@ -53,7 +53,7 @@ struct
     int major;
     int minor;
     int build;
-} version = {1,9,0};
+} version = {1,10,0};
 
 NSString* versionNumberStr()
 {
@@ -251,8 +251,8 @@ int main(int argc, char *argv[])
                @"See the icalBuddy man page for more info.\n"
                @"\n");
         Printf(@"Version %@\n", versionNumberStr());
-        Printf(@"Copyright 2008-2012 Ali Rantakari, http://hasseg.org/icalBuddy\n");
-        Printf(@"Updated to 64-bit by David Kaluta (2019), https://davidkaluta.github.io\n");
+        Printf(@"Originally by Ali Rantakari, Copyright 2008-2012 http://hasseg.org/icalBuddy\n");
+        Printf(@"Now maintained by the community\n");
         Printf(@"\n");
     }
 

--- a/icalBuddy.m
+++ b/icalBuddy.m
@@ -53,7 +53,7 @@ struct
     int major;
     int minor;
     int build;
-} version = {1,9,0};
+} version = {1,9,2};
 
 NSString* versionNumberStr()
 {

--- a/icalBuddy.m
+++ b/icalBuddy.m
@@ -53,7 +53,7 @@ struct
     int major;
     int minor;
     int build;
-} version = {1,8,10};
+} version = {1,9,0};
 
 NSString* versionNumberStr()
 {
@@ -252,6 +252,7 @@ int main(int argc, char *argv[])
                @"\n");
         Printf(@"Version %@\n", versionNumberStr());
         Printf(@"Copyright 2008-2012 Ali Rantakari, http://hasseg.org/icalBuddy\n");
+        Printf(@"Updated to 64-bit by David Kaluta (2019), https://davidkaluta.github.io\n");
         Printf(@"\n");
     }
 

--- a/icalBuddy.m
+++ b/icalBuddy.m
@@ -53,7 +53,7 @@ struct
     int major;
     int minor;
     int build;
-} version = {1,10,0};
+} version = {1,10,1};
 
 NSString* versionNumberStr()
 {

--- a/icalBuddyArgs.m
+++ b/icalBuddyArgs.m
@@ -131,11 +131,11 @@ void handleArgument(NSString *shortName, NSString *longName, id value,
         if ([value respondsToSelector:@selector(integerValue)])
         {
             if ([shortName isEqualToString:@"li"] || [longName isEqualToString:@"limitItems"])
-                prettyPrintOptions->maxNumPrintedItems = abs([value integerValue]);
+                prettyPrintOptions->maxNumPrintedItems = labs([value integerValue]);
             else if ([shortName isEqualToString:@"na"] || [longName isEqualToString:@"maxNumAttendees"])
-                opts->maxNumPrintedAttendees = abs([value integerValue]);
+                opts->maxNumPrintedAttendees = labs([value integerValue]);
             else if ([shortName isEqualToString:@"nnc"] || [longName isEqualToString:@"maxNumNoteChars"])
-                opts->maxNumNoteCharacters = abs([value integerValue]);
+                opts->maxNumNoteCharacters = labs([value integerValue]);
         }
     }
 }

--- a/icalBuddyFunctions.m
+++ b/icalBuddyFunctions.m
@@ -624,7 +624,7 @@ void filterCalendars(NSMutableArray *cals, AppOptions *opts)
 
 NSArray *getCalendars(AppOptions *opts)
 {
-    NSMutableArray *calendars = [[[[CALENDAR_STORE defaultCalendarStore] calendars] mutableCopy] autorelease];
+    NSMutableArray *calendars = [[[[[[CALENDAR_STORE alloc] init] autorelease] calendars] mutableCopy] autorelease];
     filterCalendars(calendars, opts);
     return calendars;
 }

--- a/icalBuddyPrettyPrint.m
+++ b/icalBuddyPrettyPrint.m
@@ -1060,6 +1060,7 @@ void printItemSections(NSArray *sections, CalItemPrintOption printOptions)
             && prettyPrintOptions.useCalendarColorsForTitles
             && ![[[thisOutput attributesAtIndex:0 effectiveRange:NULL] allKeys] containsObject:NSForegroundColorAttributeName]
             && section.items != nil && [section.items count] > 0
+            && [[((CalCalendarItem *)[section.items objectAtIndex:0]) calendar] color] != nil
             )
         {
             [thisOutput

--- a/icalBuddyPrettyPrint.m
+++ b/icalBuddyPrettyPrint.m
@@ -626,6 +626,7 @@ NSMutableAttributedString* getEventPropStr(NSString *propName, CalEvent *event, 
     if ([propName isEqualToString:kPropName_title]
         && prettyPrintOptions.useCalendarColorsForTitles
         && ![[[elements.value attributesAtIndex:0 effectiveRange:NULL] allKeys] containsObject:NSForegroundColorAttributeName]
+	&& [[event calendar] color] != nil
         )
         [elements.value
             addAttribute:NSForegroundColorAttributeName
@@ -1112,15 +1113,14 @@ void printAllCalendars(AppOptions *opts)
     {
         ADD_TO_OUTPUT_BUFFER(ATTR_STR(@"• "));
         NSMutableAttributedString *calendarName = M_ATTR_STR([cal title]);
-        [calendarName addAttribute:NSForegroundColorAttributeName value:[cal color] range:NSMakeRange(0, [calendarName length])];
+	if([cal color] != nil)
+	        [calendarName addAttribute:NSForegroundColorAttributeName value:[cal color] range:NSMakeRange(0, [calendarName length])];
         ADD_TO_OUTPUT_BUFFER(calendarName);
         ADD_TO_OUTPUT_BUFFER(ATTR_STR(@"\n"));
         ADD_TO_OUTPUT_BUFFER(ATTR_STR(([NSString stringWithFormat:@"  type: %@\n", [cal type]])));
         ADD_TO_OUTPUT_BUFFER(ATTR_STR(([NSString stringWithFormat:@"  UID: %@\n", [cal uid]])));
     }
 }
-
-
 
 void flushOutputBuffer(NSMutableAttributedString *buffer, AppOptions *opts, NSDictionary *formattedKeywords)
 {

--- a/icalBuddyPrettyPrint.m
+++ b/icalBuddyPrettyPrint.m
@@ -169,7 +169,7 @@ NSString* dateStr(NSDate *date, DatePrintOption printOption)
 
                     NSString *weekDiffStr = nil;
                     if (weekDiff < -1)
-                        weekDiffStr = [NSString stringWithFormat:localizedStr(kL10nKeyXWeeksAgo), abs(weekDiff)];
+                        weekDiffStr = [NSString stringWithFormat:localizedStr(kL10nKeyXWeeksAgo), labs(weekDiff)];
                     else if (weekDiff == -1)
                         weekDiffStr = localizedStr(kL10nKeyLastWeek);
                     else if (weekDiff == 0)
@@ -194,7 +194,7 @@ NSString* dateStr(NSDate *date, DatePrintOption printOption)
 
                     NSString *dayDiffStr = nil;
                     if (dayDiff < -1)
-                        dayDiffStr = [NSString stringWithFormat:localizedStr(kL10nKeyXDaysAgo), abs(dayDiff)];
+                        dayDiffStr = [NSString stringWithFormat:localizedStr(kL10nKeyXDaysAgo), labs(dayDiff)];
                     else if (dayDiff == -1)
                         dayDiffStr = localizedStr(kL10nKeyYesterday);
                     else if (dayDiff == 0)
@@ -830,7 +830,7 @@ NSString *localizedPriority(CalPriority priority)
             return localizedStr(kL10nKeyPriorityNone);
             break;
     }
-    return [NSString stringWithFormat:@"%d", priority];
+    return [NSString stringWithFormat:@"%lu", (unsigned long) priority];
 }
 
 NSString *localizedPriorityTitle(CalPriority priority)

--- a/icalBuddyPrettyPrint.m
+++ b/icalBuddyPrettyPrint.m
@@ -1060,6 +1060,7 @@ void printItemSections(NSArray *sections, CalItemPrintOption printOptions)
             && prettyPrintOptions.useCalendarColorsForTitles
             && ![[[thisOutput attributesAtIndex:0 effectiveRange:NULL] allKeys] containsObject:NSForegroundColorAttributeName]
             && section.items != nil && [section.items count] > 0
+	    && [[((CalCalendarItem *)[section.items objectAtIndex:0]) calendar] color] != nil
             )
         {
             [thisOutput

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # icalBuddy
 
-This is a command-line utility that can be used to get lists of events and tasks/to-do's from the OS X calendar database (the same one iCal uses).
+This is a command-line utility that can be used to get lists of events and tasks/to-do's from the macOS calendar database (the same one Calendar.app uses).
 
 Read more at <http://hasseg.org/icalBuddy>.
 

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,9 @@ This is a command-line utility that can be used to get lists of events and tasks
 
 Read more at <http://hasseg.org/icalBuddy>.
 
+Compiles and runs successfully on a MacBookPro15,1 running macOS 10.14.3
+Mojave.
+
 
 ## The MIT License
 

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,7 @@ This is a command-line utility that can be used to get lists of events and tasks
 
 Read more at <http://hasseg.org/icalBuddy>.
 
-Compiles and runs successfully on a MacBookPro15,1 running macOS 10.14.3
-Mojave.
+Compiles and runs successfully on macOS 10.15.0 Catalina
 
 
 ## The MIT License

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ This is a command-line utility that can be used to get lists of events and tasks
 
 Read more at <http://hasseg.org/icalBuddy>.
 
-Compiles and runs successfully on a MacBookPro15,1 running macOS 10.14.3
+Compiles and runs successfully on a MacBookPro15,2 running macOS 10.15 (Catalina)
 Mojave.
 
 


### PR DESCRIPTION
The next version of macOS, 10.15, will probably drop support for 32-bit executables.
Tested on a 2018 15-inch MacBook Pro running 10.14.3 Mojave.
Everything works.